### PR TITLE
Task 2: new strikeOff ticket 

### DIFF
--- a/db/models/Ticket.ts
+++ b/db/models/Ticket.ts
@@ -18,6 +18,7 @@ export enum TicketStatus {
 export enum TicketType {
   managementReport = 'managementReport',
   registrationAddressChange = 'registrationAddressChange',
+  strikeOff = 'strikeOff',
 }
 
 export enum TicketCategory {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,10 +4,11 @@ import { TicketsController } from './tickets/tickets.controller';
 import { ReportsController } from './reports/reports.controller';
 import { HealthcheckController } from './healthcheck/healthcheck.controller';
 import { ReportsService } from './reports/reports.service';
+import { TicketsService } from './tickets/tickets.service';
 
 @Module({
   imports: [DbModule],
   controllers: [TicketsController, ReportsController, HealthcheckController],
-  providers: [ReportsService],
+  providers: [ReportsService, TicketsService],
 })
 export class AppModule {}

--- a/src/tickets/tickets.controller.spec.ts
+++ b/src/tickets/tickets.controller.spec.ts
@@ -10,6 +10,7 @@ import {
 import { User, UserRole } from '../../db/models/User';
 import { DbModule } from '../db.module';
 import { TicketsController } from './tickets.controller';
+import { TicketsService } from './tickets.service';
 
 describe('TicketsController', () => {
   let controller: TicketsController;
@@ -17,6 +18,7 @@ describe('TicketsController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [TicketsController],
+      providers: [TicketsService],
       imports: [DbModule],
     }).compile();
 
@@ -215,6 +217,102 @@ describe('TicketsController', () => {
             `Ticket with type registrationAddressChange already exists`,
           ),
         );
+      });
+    });
+
+    describe('strikeOff', () => {
+      it('creates strikeOff ticket', async () => {
+        const company = await Company.create({ name: 'test' });
+        const user = await User.create({
+          name: 'Test User',
+          role: UserRole.director,
+          companyId: company.id,
+        });
+        const ticket = await controller.create({
+          companyId: company.id,
+          type: TicketType.strikeOff,
+        });
+
+        expect(ticket.category).toBe(TicketCategory.management);
+        expect(ticket.assigneeId).toBe(user.id);
+        expect(ticket.status).toBe(TicketStatus.open);
+      });
+
+      it('if there are multiple directors, throw', async () => {
+        const company = await Company.create({ name: 'test' });
+        await User.create({
+          name: 'Test User',
+          role: UserRole.director,
+          companyId: company.id,
+        });
+        await User.create({
+          name: 'Test User',
+          role: UserRole.director,
+          companyId: company.id,
+        });
+
+        await expect(
+          controller.create({
+            companyId: company.id,
+            type: TicketType.strikeOff,
+          }),
+        ).rejects.toEqual(
+          new ConflictException(
+            `Multiple users with role director. Cannot create a ticket`,
+          ),
+        );
+      });
+
+      it('resolved other open tickets', async () => {
+        const company = await Company.create({ name: 'test' });
+        await User.create({
+          name: 'Test User',
+          role: UserRole.director,
+          companyId: company.id,
+        });
+        const secretaries = await User.create({
+          name: 'Test User',
+          role: UserRole.corporateSecretary,
+          companyId: company.id,
+        });
+        const accountant = await User.create({
+          name: 'Test User',
+          role: UserRole.accountant,
+          companyId: company.id,
+        });
+
+        await Ticket.create({
+          companyId: company.id,
+          assigneeId: accountant.id,
+          category: TicketCategory.accounting,
+          type: TicketType.managementReport,
+          status: TicketStatus.open,
+        });
+
+        await Ticket.create({
+          companyId: company.id,
+          assigneeId: secretaries.id,
+          category: TicketCategory.corporate,
+          type: TicketType.registrationAddressChange,
+          status: TicketStatus.open,
+        });
+
+        const ticket = await controller.create({
+          companyId: company.id,
+          type: TicketType.strikeOff,
+        });
+
+        const allTickets = await Ticket.findAll();
+        const allOpen = allTickets.filter(
+          (ticket) => ticket.status === TicketStatus.open,
+        );
+        const allReolved = allTickets.filter(
+          (ticket) => ticket.status === TicketStatus.resolved,
+        );
+
+        expect(allOpen.length).toBe(1);
+        expect(allOpen[0].id).toBe(ticket.id);
+        expect(allReolved.length).toBe(2);
       });
     });
   });

--- a/src/tickets/tickets.controller.ts
+++ b/src/tickets/tickets.controller.ts
@@ -1,149 +1,44 @@
-import { Body, ConflictException, Controller, Get, Post } from '@nestjs/common';
-import { Company } from '../../db/models/Company';
-import {
-  Ticket,
-  TicketCategory,
-  TicketStatus,
-  TicketType,
-} from '../../db/models/Ticket';
-import { User, UserRole } from '../../db/models/User';
+import { Body, Controller, Get, Post } from '@nestjs/common';
+import { TicketType } from '../../db/models/Ticket';
+import { TicketsService } from './tickets.service';
 
 /**
  * Data Transfer Object for creating a new ticket
  * @interface newTicketDto
  */
 interface newTicketDto {
+  /** The type of ticket to be created */
   type: TicketType;
+  /** The ID of the company this ticket belongs to */
   companyId: number;
 }
-
-/**
- * Data Transfer Object for ticket response
- * @interface TicketDto
- */
-interface TicketDto {
-  id: number;
-  type: TicketType;
-  companyId: number;
-  assigneeId: number;
-  status: TicketStatus;
-  category: TicketCategory;
-}
-
-/** Globals */
-/** Roles that must be unique per company */
-const UNIQUE_ROLES = [UserRole.corporateSecretary, UserRole.director];
 
 /**
  * Controller for managing tickets in the ACME accounting system
- * Handles ticket creation, retrieval, and assignment logic
+ * Handles HTTP requests and delegates business logic to the service layer
  */
 @Controller('api/v1/tickets')
 export class TicketsController {
+  constructor(private readonly ticketsService: TicketsService) {}
+
   /**
    * Retrieves all tickets with their associated company and user information
-   * @returns {Promise<Ticket[]>} Array of tickets with populated company and user data
+   * @returns {Promise<any[]>} Array of tickets with populated company and user data
    */
   @Get()
   async findAll() {
-    return await Ticket.findAll({ include: [Company, User] });
+    return await this.ticketsService.findAllTickets();
   }
 
   /**
-   * Creates a new ticket with automatic assignee selection based on ticket type and business rules
-   *
-   * Business Rules:
-   * - Management Report tickets are assigned to accountants
-   * - Registration Address Change tickets are assigned to corporate secretaries
-   * - If no corporate secretary exists for registration address change, falls back to director
-   * - Only one registration address change ticket per company is allowed
-   * - Corporate secretaries or directors must be unique (only one per company)
+   * Creates a new ticket with automatic assignee selection
+   * Delegates all business logic to the service layer
    *
    * @param {newTicketDto} newTicketDto - The ticket creation data
-   * @returns {Promise<TicketDto>} The created ticket data
-   * @throws {ConflictException} When:
-   *   - Duplicate registration address change ticket exists
-   *   - No suitable assignee found for the ticket type
-   *   - Multiple corporate secretaries or directors exist (business rule violation)
+   * @returns {Promise<any>} The created ticket data
    */
   @Post()
   async create(@Body() newTicketDto: newTicketDto) {
-    const { type, companyId } = newTicketDto;
-
-    // Determine ticket category based on type
-    const category =
-      type === TicketType.managementReport
-        ? TicketCategory.accounting
-        : TicketCategory.corporate;
-
-    // Determine initial user role based on ticket type
-    let userRole =
-      type === TicketType.managementReport
-        ? UserRole.accountant
-        : UserRole.corporateSecretary;
-
-    // Check for duplicate registration address change tickets
-    // Business rule: Only one registrationAddressChange ticket per company
-    if (type === TicketType.registrationAddressChange) {
-      const existingTicket = await Ticket.findOne({
-        where: { companyId, type, status: TicketStatus.open},
-        attributes: ['id'],
-      });
-
-      if (existingTicket)
-        throw new ConflictException(`Ticket with type ${type} already exists`);
-    }
-
-    // Find users with the primary role for this ticket type
-    let assignees = await User.findAll({
-      where: { companyId, role: userRole },
-      order: [['createdAt', 'DESC']], // Get most recently created user first
-    });
-
-    // Fallback logic: If no corporate secretary exists for registration address change,
-    // try to assign to a director instead
-    if (!assignees.length && type === TicketType.registrationAddressChange) {
-      userRole = UserRole.director;
-      assignees = await User.findAll({
-        where: { companyId, role: userRole },
-        order: [['createdAt', 'DESC']],
-      });
-    }
-
-    // Validate that we have at least one assignee
-    if (!assignees.length)
-      throw new ConflictException(
-        `Cannot find user with role ${userRole} to create a ticket`,
-      );
-
-    // Business rule: Corporate secretaries or directors must be unique per company
-    if (UNIQUE_ROLES.includes(userRole) && assignees.length > 1)
-      throw new ConflictException(
-        `Multiple users with role ${userRole}. Cannot create a ticket`,
-      );
-
-    // Select the first (most recently created) assignee
-    const assignee = assignees[0];
-
-    // Create the ticket with the determined assignee and category
-    const ticket = await Ticket.create({
-      companyId,
-      assigneeId: assignee.id,
-      category,
-      type,
-      status: TicketStatus.open,
-    });
-
-    // Transform the ticket data for the response
-    const ticketDto: TicketDto = {
-      id: ticket.id,
-      type: ticket.type,
-      assigneeId: ticket.assigneeId,
-      status: ticket.status,
-      category: ticket.category,
-      companyId: ticket.companyId,
-    };
-
-    return ticketDto;
+    return await this.ticketsService.createTicket(newTicketDto);
   }
 }

--- a/src/tickets/tickets.service.ts
+++ b/src/tickets/tickets.service.ts
@@ -1,0 +1,194 @@
+import { ConflictException, Injectable } from '@nestjs/common';
+import {
+  Ticket,
+  TicketCategory,
+  TicketStatus,
+  TicketType,
+} from '../../db/models/Ticket';
+import { User, UserRole } from '../../db/models/User';
+import { Company } from '../../db/models/Company';
+import { Op } from 'sequelize';
+
+/** Globals */
+/** Roles that must be unique per company */
+const UNIQUE_ROLES = [UserRole.corporateSecretary, UserRole.director];
+
+/**
+ * Service for managing ticket business logic and operations
+ * Handles ticket creation, assignment, and validation rules
+ */
+@Injectable()
+export class TicketsService {
+  /**
+   * Creates a new ticket with automatic assignee selection based on business rules
+   *
+   * Business Rules:
+   * - Management Report tickets are assigned to accountants
+   * - Registration Address Change tickets are assigned to corporate secretaries
+   * - If no corporate secretary exists for registration address change, falls back to director
+   * - Only one registration address change ticket per company is allowed
+   * - Corporate secretaries must be unique (only one per company)
+   *
+   * @param {Object} createTicketDto - The ticket creation data
+   * @param {TicketType} createTicketDto.type - The type of ticket to create
+   * @param {number} createTicketDto.companyId - The ID of the company
+   * @returns {Promise<Object>} The created ticket data
+   * @throws {ConflictException} When business rules are violated
+   */
+  async createTicket(createTicketDto: { type: TicketType; companyId: number }) {
+    const { type, companyId } = createTicketDto;
+
+    // Determine ticket category and initial user role
+    const category = this.getCategory(type);
+    let userRole = this.getUserRole(type);
+
+    // Check for duplicate registration address change tickets
+    if (type === TicketType.registrationAddressChange) {
+      await this.checkDuplicateTicket(companyId, type);
+    }
+
+    // Find users with the primary role for this ticket type
+    let assignees = await this.findUsersByRole(companyId, userRole);
+
+    // Fallback logic: If no corporate secretary exists for registration address change,
+    // try to assign to a director instead
+    if (!assignees.length && type === TicketType.registrationAddressChange) {
+      userRole = UserRole.director;
+      assignees = await this.findUsersByRole(companyId, userRole);
+    }
+
+    // Validate that we have at least one assignee
+    if (!assignees.length) {
+      throw new ConflictException(
+        `Cannot find user with role ${userRole} to create a ticket`,
+      );
+    }
+
+    // Business rule: Corporate secretaries and directors must be unique per company
+    if (UNIQUE_ROLES.includes(userRole) && assignees.length > 1) {
+      throw new ConflictException(
+        `Multiple users with role ${userRole}. Cannot create a ticket`,
+      );
+    }
+
+    // Select the first (most recently created) assignee
+    const assignee = assignees[0];
+
+    // Create the ticket
+    const ticket = await Ticket.create({
+      companyId,
+      assigneeId: assignee.id,
+      category,
+      type,
+      status: TicketStatus.open,
+    });
+
+    // Resolve all other tickets for the company if this is a strikeOff ticket
+    if (type === TicketType.strikeOff) {
+      await this.resolveOthers(companyId, ticket.id);
+    }
+
+    // Return the ticket data
+    return {
+      id: ticket.id,
+      type: ticket.type,
+      assigneeId: ticket.assigneeId,
+      status: ticket.status,
+      category: ticket.category,
+      companyId: ticket.companyId,
+    };
+  }
+
+  /**
+   * Retrieves all tickets with their associated company and user information
+   * @returns {Promise<Ticket[]>} Array of tickets with populated company and user data
+   */
+  async findAllTickets() {
+    return await Ticket.findAll({ include: [Company, User] });
+  }
+
+  /**
+   * Checks for duplicate registration address change tickets
+   * @param {number} companyId - The company ID
+   * @param {TicketType} type - The ticket type
+   * @throws {ConflictException} When a duplicate ticket exists
+   */
+  private async checkDuplicateTicket(companyId: number, type: TicketType) {
+    const existingTicket = await Ticket.findOne({
+      where: { companyId, type, status: TicketStatus.open },
+      attributes: ['id'],
+    });
+
+    if (existingTicket) {
+      throw new ConflictException(`Ticket with type ${type} already exists`);
+    }
+  }
+
+  /**
+   * Finds users by company and role, ordered by creation date
+   * @param {number} companyId - The company ID
+   * @param {UserRole} role - The user role
+   * @returns {Promise<User[]>} Array of users matching the criteria
+   */
+  private async findUsersByRole(companyId: number, role: UserRole) {
+    return await User.findAll({
+      where: { companyId, role },
+      order: [['createdAt', 'DESC']], // Get most recently created user first
+    });
+  }
+
+  /**
+   * Get the user role for a given ticket type
+   * @param {TicketType} type - The ticket type
+   * @returns {UserRole} The user role
+   */
+  private getUserRole(type: TicketType) {
+    if (type === TicketType.managementReport) {
+      return UserRole.accountant;
+    }
+    if (type === TicketType.registrationAddressChange) {
+      return UserRole.corporateSecretary;
+    }
+    if (type === TicketType.strikeOff) {
+      return UserRole.director;
+    }
+    return UserRole.director;
+  }
+
+  /**
+   * Get the category for a given ticket type
+   * @param {TicketType} type - The ticket type
+   * @returns {TicketCategory} The category
+   */
+  private getCategory(type: TicketType) {
+    if (type === TicketType.managementReport) {
+      return TicketCategory.accounting;
+    }
+    if (type === TicketType.registrationAddressChange) {
+      return TicketCategory.corporate;
+    }
+    if (type === TicketType.strikeOff) {
+      return TicketCategory.management;
+    }
+    return TicketCategory.corporate;
+  }
+
+  /**
+   * Resolve all open tickets for a given company except the one with the given ID
+   * @param companyId - The company ID
+   * @param ticketId - The ticket ID
+   * @returns {Promise<void>}
+   */
+  private async resolveOthers(companyId: number, ticketId: number) {
+    await Ticket.update(
+      { status: TicketStatus.resolved },
+      {
+        where: {
+          companyId,
+          status: TicketStatus.open,
+          id: { [Op.ne]: ticketId },
+        },
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Code Changes
- add new `strikeOff` ticket type
- handle multiple director case
- resolved all other active tickets once the strikeOff ticket successfully created

## Stretch
- Improving code readability by adding code comments
- move the ticket business logic to service layer
- update test

## Test Plan
- `npm test`

## AI/LLM usage
- Move the business logic on the `TicketsContorller` to `TicketsService`
- Fix test setup

## Additional info
- Marking all other open tickets as resolved can be handled async (e.g using queue) to decrease latency for ticket creation endpoint. 
- Outside of test scope, marking all other tickets is better to be done once the strikeOff ticket resolved. 

